### PR TITLE
fix bound var bucketHigh to len-1 (according to paper appendix D)

### DIFF
--- a/core/lttb.go
+++ b/core/lttb.go
@@ -33,6 +33,9 @@ func LTTB(data []Point, threshold int) []Point {
 	for i := 0; i < threshold-2; i++ {
 
 		bucketHigh := int(math.Floor(float64(i+2)*bucketSize)) + 1
+		if bucketHigh >= len(data)-1 {
+			bucketHigh = len(data) - 2
+		}
 
 		// Calculate point average for next bucket (containing c)
 		avgPoint := calculateAverageDataPoint(data[bucketMiddle : bucketHigh+1])


### PR DESCRIPTION
根据论文附录D, 需要限制这边的 bucketHigh 不超过 len-1 (len 为 data 切片的长度), 否则下方取 `data[bucketMiddle : bucketHigh+1]` 会越界

例如 len(data)=256, threshold=90, 此时 `bucketSize = (len - 2) / (threshold - 2) = 254/88`, 这个循环最后一次 i=87  
`bucketHigh = floor( (i + 2) * bucketSize ) + 1 = floor( 89 * 254/88) + 1 = floor(256.88) + 1 = 257 (越界) `