### PR TITLE
refactor tests to filepath.Join instead of /

### DIFF
--- a/core/ltd_test.go
+++ b/core/ltd_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/haoel/downsampling/core"
@@ -9,11 +10,14 @@ import (
 )
 
 func BenchmarkLTD(b *testing.B) {
-	dir, _ := os.Getwd()
-	dataDir := dir + "/../demo/data/"
+	dir, err := os.Getwd()
+	if err != nil {
+		b.Fatal(err)
+	}
+	source := filepath.Join(dir, "..", "demo", "data", "source.csv")
 
 	const sampledCount = 500
-	rawdata := common.LoadPointsFromCSV(dataDir + "source.csv")
+	rawdata := common.LoadPointsFromCSV(source)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/core/ltob_test.go
+++ b/core/ltob_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/haoel/downsampling/core"
@@ -9,11 +10,14 @@ import (
 )
 
 func BenchmarkLTOB(b *testing.B) {
-	dir, _ := os.Getwd()
-	dataDir := dir + "/../demo/data/"
+	dir, err := os.Getwd()
+	if err != nil {
+		b.Fatal(err)
+	}
+	source := filepath.Join(dir, "..", "demo", "data", "source.csv")
 
 	const sampledCount = 500
-	rawdata := common.LoadPointsFromCSV(dataDir + "source.csv")
+	rawdata := common.LoadPointsFromCSV(source)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/core/lttb_test.go
+++ b/core/lttb_test.go
@@ -2,6 +2,7 @@ package core_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/haoel/downsampling/core"
@@ -9,11 +10,14 @@ import (
 )
 
 func BenchmarkLTTB(b *testing.B) {
-	dir, _ := os.Getwd()
-	dataDir := dir + "/../demo/data/"
+	dir, err := os.Getwd()
+	if err != nil {
+		b.Fatal(err)
+	}
+	source := filepath.Join(dir, "..", "demo", "data", "source.csv")
 
 	const sampledCount = 500
-	rawdata := common.LoadPointsFromCSV(dataDir + "source.csv")
+	rawdata := common.LoadPointsFromCSV(source)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -22,11 +26,14 @@ func BenchmarkLTTB(b *testing.B) {
 }
 
 func BenchmarkLTTB2(b *testing.B) {
-	dir, _ := os.Getwd()
-	dataDir := dir + "/../demo/data/"
+	dir, err := os.Getwd()
+	if err != nil {
+		b.Fatal(err)
+	}
+	source := filepath.Join(dir, "..", "demo", "data", "source.csv")
 
 	const sampledCount = 500
-	rawdata := common.LoadPointsFromCSV(dataDir + "source.csv")
+	rawdata := common.LoadPointsFromCSV(source)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This PR refactors benchmarks to use `filepath.Join` instead of manually constructed paths with `/`. Because `dir + "/../demo/data/"` is not working on OSes which have different path separators.

Also, handle `err` in `os.Getwd`.